### PR TITLE
Support multi-function components

### DIFF
--- a/src/mach/bootstrap/component.py
+++ b/src/mach/bootstrap/component.py
@@ -5,11 +5,10 @@ import unicodedata
 import click
 from cookiecutter.main import cookiecutter
 
+COOKIECUTTER_TEMPLATE = "git@github.com:labd/mach-component-cookiecutter.git"
 
-def create_component(output_dir: str, cookiecutter_location: str):
 
-    COOKIECUTTER_TEMPLATE = cookiecutter_location
-
+def create_component(output_dir: str):
     if output_dir and os.path.exists(output_dir):
         if not click.confirm(
             f"Directory {output_dir} already exists. Do you want to overwrite?"
@@ -53,8 +52,12 @@ def create_component(output_dir: str, cookiecutter_location: str):
     )
 
     context["use_public_api"] = 1 if use_public_api else 0
-    context["use_commercetools_api_extension"] = 1 if use_commercetools_api_extension else 0
-    context["use_commercetools_subscription"] = 1 if use_commercetools_subscription else 0
+    context["use_commercetools_api_extension"] = (
+        1 if use_commercetools_api_extension else 0
+    )
+    context["use_commercetools_subscription"] = (
+        1 if use_commercetools_subscription else 0
+    )
 
     if click.confirm("Use Sentry?", default=False):
         context["sentry_organization"] = click.prompt("Sentry Organization")

--- a/src/mach/commands.py
+++ b/src/mach/commands.py
@@ -216,19 +216,13 @@ def sites(file: str):
     "--output",
     help="Output file or directory.",
 )
-@click.option(
-    "-c",
-    "--cookiecutter",
-    default="git@github.com:labd/mach-component-cookiecutter.git",
-    help="cookiecutter repository to generate from.",
-)
 @click.argument("type_", required=True, type=click.Choice(["config", "component"]))
-def bootstrap(output: str, type_: str, cookiecutter: str):
+def bootstrap(output: str, type_: str):
     """Bootstraps a configuration or component."""
     if type_ == "config":
         _bootstrap.create_configuration(output or "main.yml")
     if type_ == "component":
-        _bootstrap.create_component(output, cookiecutter)
+        _bootstrap.create_component(output)
 
 
 def get_input_files(file: Optional[str]) -> List[str]:


### PR DESCRIPTION
This change asks the user what types of functionality should be included in the generated component.

This allows to combine i.e. a public API endpoint, with a commercetools subscription, which is common in many use cases (i.e. a payment service provider integration).

I've also updatet the cookiecutter for this, via https://github.com/labd/mach-component-cookiecutter/pull/1

Tests will pass once that PR is merged.

I've also added the CLI option to pass the location of the cookiecutter.