### PR TITLE
Make countries languages and currencies required

### DIFF
--- a/docs/src/syntax.md
+++ b/docs/src/syntax.md
@@ -234,11 +234,11 @@ commercetools:
 - **`client_id`** - (Required) API client ID
 - **`client_secret`** - (Required) API client secret
 - **`scopes`** - (Required) Required scopes for given API client ID.
+- **`currencies`** - (Required) List of three-digit currency codes as per ISO 4217
+- **`languages`** - (Required) List of IETF language tag
+- **`countries`** - (Required) List of two-digit country codes as per [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
 - `token_url` - Defaults to `https://auth.europe-west1.gcp.commercetools.com`
 - `api_url` - Defaults to `https://api.europe-west1.gcp.commercetools.com`
-- `currencies` - List of three-digit currency codes as per ISO 4217
-- `languages` - List of IETF language tag
-- `countries` - List of two-digit country codes as per [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
 - `messages_enabled` - When false the creation of messages is disabled.<br>
   Defaults to True
 - `channels` - List of [channel definitions](#channels)

--- a/src/mach/bootstrap/config.py
+++ b/src/mach/bootstrap/config.py
@@ -123,6 +123,12 @@ def _create_config() -> types.MachConfig:  # noqa: C901
                 f"manage_project:{ct_project} "
                 f"view_api_clients:{ct_project}"
             ),
+            # TODO: Improve this by letting user select one or more countries
+            # and generate/guess the correct languages and currencies that probably
+            # need to be applied for that project
+            languages=["nl-NL"],
+            countries=["NL"],
+            currencies=["EUR"],
         )
 
     component_config = types.ComponentConfig(

--- a/src/mach/types.py
+++ b/src/mach/types.py
@@ -249,14 +249,14 @@ class CommercetoolsSettings(JsonSchemaMixin):
     client_id: str
     client_secret: str
     scopes: str
+    currencies: List[str]
+    languages: List[str]
+    countries: List[str]
     token_url: Optional[str] = _default(
         "https://auth.europe-west1.gcp.commercetools.com"
     )
     api_url: Optional[str] = _default("https://api.europe-west1.gcp.commercetools.com")
     # CT settings
-    currencies: List[str] = _list()
-    languages: List[str] = _list()
-    countries: List[str] = _list()
     messages_enabled: Optional[bool] = _default(True)
     channels: Optional[List[CommercetoolsChannel]] = _list()
     taxes: Optional[List[CommercetoolsTax]] = _list()

--- a/tests/files/aws_config1.yml
+++ b/tests/files/aws_config1.yml
@@ -33,6 +33,9 @@ sites:
       currencies:
         - GBP
         - EUR
+      countries:
+        - NL
+        - GB
     components:
       - name: commercetools-config
       - name: payment
@@ -55,6 +58,8 @@ sites:
         - en-US
       currencies:
         - USD
+      countries:
+        - US
     components:
       - name: commercetools-config
       - name: payment

--- a/tests/files/aws_config1_expected_mach-site-eu.json
+++ b/tests/files/aws_config1_expected_mach-site-eu.json
@@ -98,7 +98,10 @@
             "mach-site-eu"
           ],
           "countries": [
-            []
+            [
+              "NL",
+              "GB"
+            ]
           ],
           "currencies": [
             [

--- a/tests/files/aws_config1_expected_mach-site-us.json
+++ b/tests/files/aws_config1_expected_mach-site-us.json
@@ -98,7 +98,9 @@
             "mach-site-us"
           ],
           "countries": [
-            []
+            [
+              "US"
+            ]
           ],
           "currencies": [
             [

--- a/tests/files/azure_config1.yml
+++ b/tests/files/azure_config1.yml
@@ -39,6 +39,9 @@ sites:
       currencies:
         - GBP
         - EUR
+      countries:
+        - NL
+        - GB
     components:
       - name: commercetools-config
       - name: payment
@@ -57,6 +60,8 @@ sites:
         - en-US
       currencies:
         - USD
+      countries:
+        - US
     components:
       - name: commercetools-config
       - name: payment

--- a/tests/files/azure_config1_expected_mach-site-eu.json
+++ b/tests/files/azure_config1_expected_mach-site-eu.json
@@ -104,7 +104,10 @@
             "mach-site-eu"
           ],
           "countries": [
-            []
+            [
+              "NL",
+              "GB"
+            ]
           ],
           "currencies": [
             [

--- a/tests/files/azure_config1_expected_mach-site-us.json
+++ b/tests/files/azure_config1_expected_mach-site-us.json
@@ -104,7 +104,9 @@
             "mach-site-us"
           ],
           "countries": [
-            []
+            [
+              "US"
+            ]
           ],
           "currencies": [
             [

--- a/tests/unittests/test_terraform.py
+++ b/tests/unittests/test_terraform.py
@@ -168,6 +168,9 @@ def test_generate_w_stores(config: types.MachConfig, tf_mock):
         client_id="a96e59be-24da-4f41-a6cf-d61d7b6e1766",
         client_secret="98c32de8-1a6c-45a9-a718-d3cce5201799",
         scopes="manage_project:ct-unit-test",
+        languages=["nl-NL"],
+        countries=["NL"],
+        currencies=["EUR"],
         stores=[
             types.Store(
                 name={

--- a/tests/unittests/test_validate.py
+++ b/tests/unittests/test_validate.py
@@ -125,6 +125,9 @@ def test_validate_store_keys(name, valid):
         client_id="a96e59be-24da-4f41-a6cf-d61d7b6e1766",
         client_secret="98c32de8-1a6c-45a9-a718-d3cce5201799",
         scopes="manage_project:ct-unit-test",
+        languages=["nl-NL"],
+        countries=["NL"],
+        currencies=["EUR"],
         stores=[
             types.Store(
                 key=name,
@@ -181,6 +184,9 @@ def test_validate_stores(parsed_config: types.MachConfig):
         client_id="a96e59be-24da-4f41-a6cf-d61d7b6e1766",
         client_secret="98c32de8-1a6c-45a9-a718-d3cce5201799",
         scopes="manage_project:ct-unit-test",
+        languages=["nl-NL"],
+        countries=["NL"],
+        currencies=["EUR"],
         stores=[
             types.Store(
                 name={


### PR DESCRIPTION
This is required in the commercetools API when setting the commercetools project.
We need these project settings in order to enable messages, so we also need to require the additional fields