### PR TITLE
Support `mach apply --component x --componennt y` to speed up deploys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
     - `mach bootstrap config` for creating a new MACH configuration
     - `mach bootstrap component` for creating a new MACH component
 - Add `--site` option to the `generate`, `plan` and `apply` commands
+- Add `--component` option to the `plan` and `apply` commands
 - Updated Terraform commercetools provider to `0.25.3`
 - AWS: Set `auto-deploy` on API gateway stage
 - Azure: Add new required `frontdoor_id` Terraform variable for components with `endpoint` defined

--- a/docs/src/workflow/cli.md
+++ b/docs/src/workflow/cli.md
@@ -34,6 +34,7 @@ mach apply --auto-approve -f main.yml
 - `--auto-approve` Auto-approve the Terraform plan
 - `--file` or `-f TEXT` YAML file to apply. If not set apply all *.yml files.
 - `--site` or `-s TEXT` Site to apply. If not set apply all sites.
+- `--component` or `-c TEXT` Specific component to target.
 - `--output-path TEXT` Output path, defaults to `cwd`/deployments`.
 
 
@@ -93,6 +94,7 @@ mach plan -f main.yml
 
 - `--file` or `-f TEXT` YAML file to parse. If not set parse all *.yml files.
 - `--site` or `-s TEXT` Site to generate plan of. If not set generate plans for all sites.
+- `--component` or `-c TEXT` Specific component to target.
 - `--output-path TEXT` Output path, defaults to `cwd`/deployments.
 
 

--- a/src/mach/commands.py
+++ b/src/mach/commands.py
@@ -75,14 +75,22 @@ def generate(file, site, configs, *args, **kwargs):
     help="If az login with service principal environment variables "
     "(ARM_CLIENT_ID, ARM_CLIENT_SECRET, ARM_TENANT_ID) should be done.",
 )
+@click.option(
+    "-c",
+    "--component",
+    multiple=True,
+    default=False,
+    help="",
+)
 @terraform_command
-def plan(file, site, configs, with_sp_login, *args, **kwargs):
+def plan(file, site, configs, with_sp_login, component, *args, **kwargs):
     """Output the deploy plan."""
     for config in configs:
         generate_terraform(config, site=site)
         plan_terraform(
             config,
             site=site,
+            components=component,
             with_sp_login=with_sp_login,
         )
 
@@ -102,6 +110,7 @@ def plan(file, site, configs, with_sp_login, *args, **kwargs):
     help="",
 )
 @click.option(
+    "-c",
     "--component",
     multiple=True,
     default=False,
@@ -115,9 +124,9 @@ def apply(file, site, configs, with_sp_login, auto_approve, component, *args, **
         apply_terraform(
             config,
             site=site,
+            components=component,
             with_sp_login=with_sp_login,
             auto_approve=auto_approve,
-            component=component,
         )
 
 

--- a/src/mach/terraform.py
+++ b/src/mach/terraform.py
@@ -43,7 +43,11 @@ def _clean_tf(content: str) -> str:
 
 
 def plan_terraform(
-    config: MachConfig, *, site: str = None, with_sp_login: bool = False
+    config: MachConfig,
+    *,
+    site: str = None,
+    components: List[str] = [],
+    with_sp_login: bool = False,
 ):
     """Terraform init and plan for all generated sites."""
     sites = _filter_sites(config.sites, site)
@@ -59,16 +63,20 @@ def plan_terraform(
         if with_sp_login:
             azure_sp_login()
 
-        run_terraform("plan", site_dir)
+        cmd = ["plan"]
+        for component in components:
+            cmd.append(f"-target=module.{component}")
+
+        run_terraform(cmd, site_dir)
 
 
 def apply_terraform(
     config: MachConfig,
     *,
     site: str = None,
+    components: List[str] = [],
     with_sp_login: bool = False,
     auto_approve: bool = False,
-    component: List[str] = [],
 ):
     """Terraform apply for all generated sites."""
     sites = _filter_sites(config.sites, site)
@@ -88,8 +96,8 @@ def apply_terraform(
         if auto_approve:
             cmd += ["-auto-approve"]
 
-        for component_name in component:
-            cmd.append(f"-target=module.{component_name}")
+        for component in components:
+            cmd.append(f"-target=module.{component}")
         run_terraform(cmd, site_dir)
 
 


### PR DESCRIPTION
When developing locally it makes sense to sometimes only update a single
component and speed up the iteration process

