### PR TITLE
adding note about how to add GCP support

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
   - prerequisites/index.md
   - Azure: prerequisites/azure.md
   - AWS: prerequisites/aws.md
+  - GCP: prerequisites/gcp.md
 - gettingstarted.md
 - Syntax:
   - Overview: syntax/index.md

--- a/docs/src/prerequisites/gcp.md
+++ b/docs/src/prerequisites/gcp.md
@@ -1,0 +1,14 @@
+# Setting up GCP
+
+!!! todo
+    GCP is not yet supported by MACH composer, unfortunately.
+    We are happy to accept contributions to add this! And think with you if you plan to work on it. Feel free to reach out to us via [opensource@labdigital.nl](opensource@labdigital.nl).
+
+## What needs to happen to support GCP?
+
+Luckily, adding GCP should not be a lot of work. Most of the implementation boils down to adding the right terraform code in MACH composer, to generate the nessesary resources. This is primarily about setting up an API gateway that ties together many services, through [GCP's Terraform support](https://registry.terraform.io/providers/hashicorp/google/latest/docs).
+
+- [ ] Add support in MACH yaml to support GCP cloud
+- [ ] Add terraform templates to MACH composer, to support GCP resources
+- [ ] Reference implementation of a CloudRun serverless function
+- [ ] Base Google Cloud account setup where the architecture runs in


### PR DESCRIPTION
I spoke to another commercetools partner today, and they are looking in to MACH composer. However, they are on GCP. So I thought to create a page that described how to add GCP support :-).

Perhaps you can add to the list, @tleguijt ?