### PR TITLE
Combine component endpoints into one variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@
     description = "Tags to be used on resources."
   }
   ```
-- **component**: Add `aws_endpoint_*` variable when the `endpoints` configuration option is used. [More information](https://docs.machcomposer.io/reference/components/aws.html#with-endpoints) on defining and using endpoints in AWS.
+- **component**: Add `aws_endpoints` variable when the `endpoints` configuration option is used. [More information](https://docs.machcomposer.io/reference/components/aws.html#with-endpoints) on defining and using endpoints in AWS.
 
 **Azure**
 
@@ -97,7 +97,7 @@
   terraform state mv azurerm_dns_cname_record.<project-key> azurerm_dns_cname_record.<endpoint-key>
   ```
 - **component**: Prefixed **all** Azure-specific variables with `azure_`
-- **component**: The `FRONTDOOR_ID` value is removed from the `var.variables` of a component. Replaced with `var.azure_endpoint_*`. [More information](https://docs.machcomposer.io/reference/components/azure.html#with-endpoints) on defining and using endpoints in Azure.
+- **component**: The `FRONTDOOR_ID` value is removed from the `var.variables` of a component. Replaced with `var.azure_endpoints`. [More information](https://docs.machcomposer.io/reference/components/azure.html#with-endpoints) on defining and using endpoints in Azure.
 - **component**: `app_service_plan_id` has been replaced with `azure_app_service_plan` containing both an `id` and `name` so the [azurerm_app_service_plan](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/app_service_plan) data source can be used in a component.<br>
   It will *only be set* when `service_plan` is configured in the component [definition](https://docs.machcomposer.io/reference/syntax/components.html#azure) or [site configuration](https://docs.machcomposer.io/reference/syntax/sites.html#azure_1)
   ```terraform

--- a/docs/src/reference/components/aws.md
+++ b/docs/src/reference/components/aws.md
@@ -12,25 +12,37 @@ In addition to the [base variables](./structure.md#required-variables) AWS compo
 
 ### With `endpoints`
 
-In order to support the [`endpoints`](../../topics/deployment/config/aws.md#http-routing) attribute on the component, the component needs to define what endpoints it expects.
-
-For example, if the component requires two endpoints (`main` and `webhooks`) to be set, the following variables needs to be defined:
+In order to support the [`endpoints`](../../topics/deployment/config/aws.md#http-routing) attribute on the component, the component needs to define a `aws_endpoints` variable:
 
 ```terraform
-variable "aws_endpoint_main" {
-  type = object({
+variable "aws_endpoints" {
+  type = map(object({
     url                       = string
     api_gateway_id            = string
     api_gateway_execution_arn = string
-  })
+  }))
 }
+```
 
-variable "aws_endpoint_webhooks" {
-  type = object({
+For example, if the component requires two endpoints (`main` and `webhooks`) to be set, the necessary information can be used by using `var.aws_endpoints.main` and `var.aws_endpoints.webhooks`.
+
+We could also enforce these values to be defined on variable level:
+
+```terraform
+variable "aws_endpoints" {
+  type = map(object({
     url                       = string
     api_gateway_id            = string
     api_gateway_execution_arn = string
-  })
+  }))
+
+  validation {
+    condition = length(setsubtract(
+      ["main", "webhooks"], 
+      keys(var.azure_endpoints))
+    ) == 0
+    error_message = "Endpoints should have 'main' and 'webhooks' defined."
+  }
 }
 ```
 

--- a/docs/src/reference/components/azure.md
+++ b/docs/src/reference/components/azure.md
@@ -60,25 +60,37 @@ variable "azure_monitor_action_group_id" {
 
 ### With `endpoints`
 
-In order to support the [`endpoints`](../../topics/deployment/config/azure.md#http-routing) attribute on the component, the component needs to define what endpoints it expects.
-
-For example, if the component requires two endpoints (`main` and `webhooks`) to be set, the following variables needs to be defined:
+In order to support the [`endpoints`](../../topics/deployment/config/azure.md#http-routing) attribute on the component, the component needs to define a `azure_endpoints` variable:
 
 ```terraform
-variable "azure_endpoint_main" {
-  type = object({
+variable "azure_endpoints" {
+  type = map(object({
     url          = string
     frontdoor_id = string
-  })
-}
-
-variable "azure_endpoint_webhooks" {
-  type = object({
-    url          = string
-    frontdoor_id = string
-  })
+  }))
 }
 ```
+
+For example, if the component requires two endpoints (`main` and `webhooks`) to be set, the necessary information can be used by using `var.azure_endpoints.main` and `var.azure_endpoints.webhooks`.
+
+We could also enforce these values to be defined on variable level:
+
+```terraform
+variable "azure_endpoints" {
+  type = map(object({
+    url          = string
+    frontdoor_id = string
+  }))
+
+  validation {
+    condition = length(setsubtract(
+      ["main", "webhooks"], 
+      keys(var.azure_endpoints))
+    ) == 0
+    error_message = "Endpoints should have 'main' and 'webhooks' defined."
+  }
+}
+``` 
 
 ### With `service_plan`
 

--- a/docs/src/topics/deployment/config/components.md
+++ b/docs/src/topics/deployment/config/components.md
@@ -13,13 +13,13 @@ Some of the components are referenced through the Terraform variables and can be
 
 ```terraform
 resource "aws_apigatewayv2_integration" "gateway" {
-    api_id           = var.aws_endpoint_main.api_gateway_id
+    api_id           = var.aws_endpoints.main.api_gateway_id
     integration_type = "AWS_PROXY"
     integration_uri  = local.lambda_function_arn
 }
 
 resource "aws_apigatewayv2_route" "app_route" {
-    api_id    = var.aws_endpoint_main.api_gateway_id
+    api_id    = var.aws_endpoints.main.api_gateway_id
     route_key = "ANY /graphql/{proxy+}"
     target    = "integrations/${aws_apigatewayv2_integration.gateway.id}"
 }

--- a/src/mach/templates/partials/component_aws_variables.tf
+++ b/src/mach/templates/partials/component_aws_variables.tf
@@ -1,10 +1,14 @@
-{% for component_endpoint, site_endpoint in component.endpoints.items() -%}
-aws_endpoint_{{ component_endpoint|slugify }} = {
-  url = local.endpoint_url_{{ site_endpoint|slugify }}
-  api_gateway_id = aws_apigatewayv2_api.{{ site_endpoint|slugify }}_gateway.id
-  api_gateway_execution_arn = aws_apigatewayv2_api.{{ site_endpoint|slugify }}_gateway.execution_arn
+{% if component.endpoints %}
+aws_endpoints = {
+  {% for component_endpoint, site_endpoint in component.endpoints.items() -%}
+  {{ component_endpoint|slugify }} = {
+    url = local.endpoint_url_{{ site_endpoint|slugify }}
+    api_gateway_id = aws_apigatewayv2_api.{{ site_endpoint|slugify }}_gateway.id
+    api_gateway_execution_arn = aws_apigatewayv2_api.{{ site_endpoint|slugify }}_gateway.execution_arn
+  }
+  {% endfor %}
 }
-{% endfor %}
+{% endif %}
 
 # Won't be prefixed; since in theory this could be used for other cloud integrations as well
 {% if definition.artifacts %}

--- a/src/mach/templates/partials/component_azure_variables.tf
+++ b/src/mach/templates/partials/component_azure_variables.tf
@@ -18,9 +18,13 @@ azure_app_service_plan        = {
 {% if site.azure.alert_group %}
 azure_monitor_action_group_id = azurerm_monitor_action_group.alert_action_group.id
 {% endif %}
-{% for component_endpoint, site_endpoint in component.endpoints.items() -%}
-azure_endpoint_{{ component_endpoint|slugify }} = {
-  url = local.endpoint_url_{{ site_endpoint|slugify }}
-  frontdoor_id = azurerm_frontdoor.app-service.header_frontdoor_id
+{% if component.endpoints %}
+azure_endpoints = {
+  {% for component_endpoint, site_endpoint in component.endpoints.items() -%}
+  {{ component_endpoint|slugify }} = {
+    url = local.endpoint_url_{{ site_endpoint|slugify }}
+    frontdoor_id = azurerm_frontdoor.app-service.header_frontdoor_id
+  }
+  {% endfor %}
 }
-{% endfor %}
+{% endif %}

--- a/tests/files/aws_config1_expected_mach-site-eu.json
+++ b/tests/files/aws_config1_expected_mach-site-eu.json
@@ -432,11 +432,13 @@
         "secrets": [
           {}
         ],
-        "aws_endpoint_public": [
+        "aws_endpoints": [
           {
-            "url": "${local.endpoint_url_main}",
-            "api_gateway_id": "${aws_apigatewayv2_api.main_gateway.id}",
-            "api_gateway_execution_arn": "${aws_apigatewayv2_api.main_gateway.execution_arn}"
+            "public": {
+              "url": "${local.endpoint_url_main}",
+              "api_gateway_id": "${aws_apigatewayv2_api.main_gateway.id}",
+              "api_gateway_execution_arn": "${aws_apigatewayv2_api.main_gateway.execution_arn}"
+            }
           }
         ],
         "ct_project_key": [

--- a/tests/files/aws_config1_expected_mach-site-us.json
+++ b/tests/files/aws_config1_expected_mach-site-us.json
@@ -312,11 +312,13 @@
         "secrets": [
           {}
         ],
-        "aws_endpoint_public": [
+        "aws_endpoints": [
           {
-            "url": "${local.endpoint_url_default}",
-            "api_gateway_id": "${aws_apigatewayv2_api.default_gateway.id}",
-            "api_gateway_execution_arn": "${aws_apigatewayv2_api.default_gateway.execution_arn}"
+            "public": {
+              "url": "${local.endpoint_url_default}",
+              "api_gateway_id": "${aws_apigatewayv2_api.default_gateway.id}",
+              "api_gateway_execution_arn": "${aws_apigatewayv2_api.default_gateway.execution_arn}"
+            }
           }
         ],
         "ct_project_key": [

--- a/tests/files/azure_config1_expected_mach-site-eu.json
+++ b/tests/files/azure_config1_expected_mach-site-eu.json
@@ -532,10 +532,12 @@
             "location": "${local.resource_group_location}"
           }
         ],
-        "azure_endpoint_public": [
+        "azure_endpoints": [
           {
-            "url": "${local.endpoint_url_default}",
-            "frontdoor_id": "${azurerm_frontdoor.app-service.header_frontdoor_id}"
+            "public": {
+              "url": "${local.endpoint_url_default}",
+              "frontdoor_id": "${azurerm_frontdoor.app-service.header_frontdoor_id}"
+            }
           }
         ],
         "ct_project_key": [

--- a/tests/files/azure_config1_expected_mach-site-us.json
+++ b/tests/files/azure_config1_expected_mach-site-us.json
@@ -626,10 +626,12 @@
             "name": "${azurerm_app_service_plan.functionapps_premium.name}"
           }
         ],
-        "azure_endpoint_public": [
+        "azure_endpoints": [
           {
-            "url": "${local.endpoint_url_public}",
-            "frontdoor_id": "${azurerm_frontdoor.app-service.header_frontdoor_id}"
+            "public": {
+              "url": "${local.endpoint_url_public}",
+              "frontdoor_id": "${azurerm_frontdoor.app-service.header_frontdoor_id}"
+            }
           }
         ],
         "ct_project_key": [


### PR DESCRIPTION
This combines all component endpoints into one variable.

It makes it less explicit on variable definition level, but your rollout will still throw an error when not all required endpoints are defined in your configuration (because referring to for example `var.aws_endpoints.private` will throw an error if `private` is not set by MACH.

However, with variable validation we have an option to make this more explicit and validate the input before it is actually used.
This will also part of the documentation:

![image](https://user-images.githubusercontent.com/1533933/110313224-6f46c480-8006-11eb-8d02-388791d20a97.png)
