### PR TITLE
feat(commands): allow at delimiter for version number

### DIFF
--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -101,7 +101,7 @@ mach plan -f main.yml
 - `--output-path TEXT` Output path, defaults to `cwd`/deployments.
 - `--reuse` Supress a terraform init for improved speed (not recommended for production usage)
 - `--ignore-version` Skip MACH composer version check
-  
+
 
 ## `sites`
 List all sites.
@@ -130,6 +130,9 @@ mach update --check
 
 # To update a specific component and create a commit message
 mach update pim-importer v1.2.0 -c
+
+# You can also use the "@" delimiter for component version
+mach update pim-importer@v1.2.0 -c
 ```
 
 **Options**

--- a/src/mach/commands.py
+++ b/src/mach/commands.py
@@ -215,9 +215,11 @@ def update(
         )
 
     if component and not version:
-        raise click.ClickException(
-            f"When specifying a component ({component}) you should specify a version as well"
-        )
+        if "@" not in component:
+            raise click.ClickException(
+                f"When specifying a component ({component}) you should specify a version as well"
+            )
+        component, version = component.split("@")
 
     for file in get_input_files(file):
         updater.update_file(


### PR DESCRIPTION
I automatically try to use the `@` delimiter for component and version number so seems like a nice feature to add.﻿
