### PR TITLE
Update docs after mach composer move between orgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ brew install mach-composer
 
 ### Windows
 
-Windows installation through Chocolatery is currently unstable. We recommend to [download the latest release from Github 
+Windows installation through Chocolatery is currently unstable. We recommend to [download the latest release from GitHub
 Releases](https://github.com/mach-composer/mach-composer-cli/releases/latest). Also, it is recommended to run MACH composer through [WSL](https://learn.microsoft.com/en-us/windows/wsl/install).
 
 <!--```ps

--- a/docs/src/howto/ci/github.md
+++ b/docs/src/howto/ci/github.md
@@ -198,7 +198,7 @@ function app ZIP file.
 
 ### Example
 
-Example GitHub action to package and deploy a component on AWS.
+Example GitHub Action to package and deploy a component on AWS.
 
 === "Node"
 

--- a/docs/src/topics/deployment/components.md
+++ b/docs/src/topics/deployment/components.md
@@ -144,7 +144,7 @@ Refer to the CI/CD section for instructions on how to set up your Continuous
 Integration pipeline for component deployments:
 
 - [GitLab](../../howto/ci/gitlab.md#component-deployment)
-- [GitHub actions](../../howto/ci/github.md#component-deployment)
+- [GitHub Actions](../../howto/ci/github.md#component-deployment)
 - [Azure DevOps](../../howto/ci/devops.md#component-deployment)
 
 

--- a/docs/src/topics/deployment/config/index.md
+++ b/docs/src/topics/deployment/config/index.md
@@ -109,5 +109,5 @@ docker run --rm \
     For an example on how to set up the Terraform plugin cache, see the examples in the how-tos for:
 
     - [GitLab](../../../howto/ci/gitlab.md#terraform-plugin-cache)
-    - GitHub actions (todo)
+    - GitHub Actions (todo)
     - Azure DevOps (todo)

--- a/docs/src/topics/development/environment.md
+++ b/docs/src/topics/development/environment.md
@@ -9,7 +9,7 @@ MACH composer is written in Go. For macOS and Linux users the easiest way to
 install MACH composer is via brew:
 
 ```bash
-brew tap labd/mach-composer
+brew tap mach-composer/mach-composer
 brew install mach-composer
 ```
 
@@ -22,7 +22,7 @@ following configuration:
 ```json
 {
   "yaml.schemas": {
-    "https://raw.githubusercontent.com/labd/mach-composer/main/internal/config/schemas/schema-1.yaml": "*.yml"
+    "https://raw.githubusercontent.com/mach-composer/mach-composer-cli/main/internal/config/schemas/schema-1.yaml": "*.yml"
   }
 }
 ```

--- a/docs/src/tutorial/step-1-installation.md
+++ b/docs/src/tutorial/step-1-installation.md
@@ -8,7 +8,7 @@ to perform a MACH composer deploy and make use of the
 
 ### MacOS and linux
 ```bash
-brew tap labd/mach-composer
+brew tap mach-composer/mach-composer
 brew install mach-composer
 ```
 


### PR DESCRIPTION
<!--

Write a short description of your changes. Examples:

- Fixed a bug
- Added a new feature
- Updated documentation

--> 

This PR contains some minor tweaks to the documentation to:
- Update outdated references after the move from the @labd to @mach-composer org
- Make the capitalization of "GitHub" and "GitHub Actions" consistent with the rest of the docs

I expect to create another PR with some more substantial docs changes after I've had a chance to familiarize myself with the project more, but I figured it might be good to get this merged in the meantime.