### PR TITLE
fix: small tweak to make git source reference addition more explicit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 deployments/
 dist/
 local/
+vendor/
 /output
 /coverage.html
 /coverage.out
@@ -24,3 +25,4 @@ __pycache__
 
 # binaries
 /bin
+mach-composer

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -5,9 +5,10 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/mach-composer/mach-composer-cli/internal/state"
 	"log"
 	"strings"
+
+	"github.com/mach-composer/mach-composer-cli/internal/state"
 
 	"github.com/elliotchance/pie/v2"
 	"github.com/mach-composer/mcc-sdk-go/mccsdk"
@@ -195,11 +196,7 @@ func (sc SiteComponent) HasCloudIntegration(g *GlobalConfig) bool {
 	return pie.Contains(sc.Definition.Integrations, g.Cloud)
 }
 
-// UseVersionReference indicates if the module should be referenced with the
-// version.
-// This will be mainly used for development purposes when referring to a local
-// directory; versioning is not possible, but we should still be able to define
-// a version in our component for the actual function deployment itself.
-func (c *Component) UseVersionReference() bool {
+// IsGitSource indicates if the source definition refers to Git.
+func (c *Component) IsGitSource() bool {
 	return strings.HasPrefix(c.Source, "git")
 }

--- a/internal/generator/generate.go
+++ b/internal/generator/generate.go
@@ -3,9 +3,10 @@ package generator
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/elliotchance/pie/v2"
 	"github.com/mach-composer/mach-composer-cli/internal/utils"
-	"strings"
 
 	"github.com/mach-composer/mach-composer-cli/internal/config"
 	"github.com/mach-composer/mach-composer-cli/internal/variables"
@@ -260,7 +261,10 @@ func renderComponent(_ context.Context, cfg *config.MachConfig, site *config.Sit
 		tc.ComponentSecrets = val
 	}
 
-	if component.Definition.UseVersionReference() {
+	if component.Definition.IsGitSource() {
+		// When using Git, we will automatically add a reference to the string
+		// so that the given version is used when fetching the module itself
+		// from Git as well
 		tc.Source += fmt.Sprintf("?ref=%s", component.Definition.Version)
 	}
 


### PR DESCRIPTION
Renamed `UseVersionReference` to `IsGitSource` because it better reflects what it does, and how the function is used.

We can't just attach the `?ref` string to **any** source; this is an specific syntax for the git source, so we want to make sure we're dealing with one.

Altho this doesn't change the behaviour itself, it will make the code a bit more explicit