### PR TITLE
feat: rename remote_state plugin to backend

### DIFF
--- a/internal/config/parse_global.go
+++ b/internal/config/parse_global.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+
 	"github.com/mach-composer/mach-composer-cli/internal/cli"
 	"gopkg.in/yaml.v3"
 )
@@ -40,7 +41,7 @@ func parseGlobalNode(cfg *MachConfig, globalNode *yaml.Node) error {
 			cli.DeprecationWarning(&cli.DeprecationOptions{
 				Message: "the usage of `aws_remote_state` is deprecated and will be removed in the next major version",
 				Details: `
-				Please move the configuration to the remote_state block and add the provider name as plugin.
+				Please move the configuration to the remote_state block and add the provider name as backend.
 				
 				For example:
 				
@@ -52,7 +53,7 @@ func parseGlobalNode(cfg *MachConfig, globalNode *yaml.Node) error {
 				To:
 				
 				    remote_state:
-					  plugin: aws
+					  backend: aws
 					  key_prefix: mach-composer
 					  region: eu-central-1
 					  bucket: "mcc-terraform-state"
@@ -70,7 +71,7 @@ func parseGlobalNode(cfg *MachConfig, globalNode *yaml.Node) error {
 			cli.DeprecationWarning(&cli.DeprecationOptions{
 				Message: "the usage of `azure_remote_state` is deprecated and will be removed in the next major version",
 				Details: `
-				Please move the configuration to the remote_state block and add the provider name as plugin.
+				Please move the configuration to the remote_state block and add the provider name as backend.
 				
 				For example:
 				
@@ -82,7 +83,7 @@ func parseGlobalNode(cfg *MachConfig, globalNode *yaml.Node) error {
 				To:
 				
 				    remote_state:
-						plugin: azure
+						backend: azure
 						resource_group: some-resource-group
 						storage_account: some-account
 						container_name: some-container
@@ -102,12 +103,12 @@ func parseGlobalNode(cfg *MachConfig, globalNode *yaml.Node) error {
 				return err
 			}
 
-			pluginName, ok := data["plugin"].(string)
+			backendName, ok := data["backend"].(string)
 			if !ok {
-				return fmt.Errorf("plugin needs to be defined for remote_state")
+				return fmt.Errorf("backend needs to be defined for remote_state")
 			}
 
-			cfg.Global.TerraformStateProvider = pluginName
+			cfg.Global.TerraformStateProvider = backendName
 			return nil
 		}
 	}

--- a/internal/config/schemas/schema-1.yaml
+++ b/internal/config/schemas/schema-1.yaml
@@ -90,9 +90,9 @@ definitions:
           - type: object
             additionalProperties: true
             required:
-              - plugin
+              - backend
             properties:
-              plugin:
+              backend:
                 type: string
                 enum:
                   - aws

--- a/internal/state/schemas/aws.schema.json
+++ b/internal/state/schemas/aws.schema.json
@@ -8,7 +8,7 @@
     "region"
   ],
   "properties": {
-    "plugin": {
+    "backend": {
       "type": "string"
     },
     "bucket": {

--- a/internal/state/schemas/azure.schema.json
+++ b/internal/state/schemas/azure.schema.json
@@ -8,7 +8,7 @@
     "container_name"
   ],
   "properties": {
-    "plugin": {
+    "backend": {
       "type": "string"
     },
     "resource_group": {

--- a/internal/state/schemas/gcp.schema.json
+++ b/internal/state/schemas/gcp.schema.json
@@ -6,7 +6,7 @@
     "bucket"
   ],
   "properties": {
-    "plugin": {
+    "backend": {
       "type": "string"
     },
     "bucket": {

--- a/internal/state/schemas/local.schema.json
+++ b/internal/state/schemas/local.schema.json
@@ -3,7 +3,7 @@
   "description": "Local state backend configuration.",
   "additionalProperties": false,
   "properties": {
-    "plugin": {
+    "backend": {
       "type": "string"
     },
     "path": {

--- a/internal/state/schemas/terraform_cloud.schema.json
+++ b/internal/state/schemas/terraform_cloud.schema.json
@@ -6,7 +6,7 @@
     "organization"
   ],
   "properties": {
-    "plugin": {
+    "backend": {
       "type": "string"
     },
     "hostname": {

--- a/internal/state/terraform_cloud.go
+++ b/internal/state/terraform_cloud.go
@@ -64,7 +64,7 @@ func (tcr *TerraformCloudRenderer) RemoteState() (string, error) {
 
 	template := `
 	data "terraform_remote_state" "{{ .Key }}" {
-	  backend = "aws"
+	  backend = "remote"
 	
 	  config = {
 	    organization = "{{ .State.Organization }}"


### PR DESCRIPTION
Rename `plugin` to `backend` since it avoids confusion with the MACH composer plugins, and is more in line with how terraform names it.

We might also consider renaming the values itself;
- `aws` -> `s3`
- `gcp` -> `gcs`

**todo**
- [ ] Still support `plugin` for backwards compatibility 