### PR TITLE
Fix inconsistent yaml file import root

### DIFF
--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -3,9 +3,9 @@ package config
 import (
 	"context"
 	"fmt"
-	"github.com/mach-composer/mach-composer-cli/internal/state"
-	"path"
 	"path/filepath"
+
+	"github.com/mach-composer/mach-composer-cli/internal/state"
 
 	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v3"
@@ -95,7 +95,7 @@ func loadConfig(ctx context.Context, filename string, pr *plugins.PluginReposito
 		return nil, err
 	}
 
-	if _, err := LoadRefData(ctx, &raw.Components, path.Dir(filename)); err != nil {
+	if _, err := LoadRefData(ctx, &raw.Components); err != nil {
 		return nil, err
 	}
 

--- a/internal/config/parse_test.go
+++ b/internal/config/parse_test.go
@@ -353,7 +353,7 @@ func TestParseComponentsNodeRef(t *testing.T) {
 	err = yaml.Unmarshal(data, &intermediate)
 	require.NoError(t, err)
 
-	_, err = LoadRefData(context.Background(), &intermediate.Components, "")
+	_, err = LoadRefData(context.Background(), &intermediate.Components)
 	require.NoError(t, err)
 
 	cfg := &MachConfig{

--- a/internal/config/utils.go
+++ b/internal/config/utils.go
@@ -3,7 +3,6 @@ package config
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/elliotchance/pie/v2"
@@ -60,7 +59,7 @@ func iterateYamlNodes(
 	return nil
 }
 
-func LoadRefData(ctx context.Context, node *yaml.Node, cwd string) (string, error) {
+func LoadRefData(ctx context.Context, node *yaml.Node) (string, error) {
 	if node.Kind != yaml.MappingNode {
 		return "", nil
 	}
@@ -71,7 +70,7 @@ func LoadRefData(ctx context.Context, node *yaml.Node, cwd string) (string, erro
 		return "", nil
 	}
 
-	newNode, err := loadRefDocument(ctx, ref.Value, cwd)
+	newNode, err := loadRefDocument(ctx, ref.Value)
 	if err != nil {
 		return "", err
 	}
@@ -81,9 +80,9 @@ func LoadRefData(ctx context.Context, node *yaml.Node, cwd string) (string, erro
 	return ref.Value, nil
 }
 
-func loadRefDocument(ctx context.Context, filename, cwd string) (*yaml.Node, error) {
+func loadRefDocument(ctx context.Context, filename string) (*yaml.Node, error) {
 	parts := strings.SplitN(filename, "#", 2)
-	fname := filepath.Join(cwd, parts[0])
+	fname := parts[0]
 
 	body, err := utils.AFS.ReadFile(fname)
 	if err != nil {

--- a/internal/config/utils_test.go
+++ b/internal/config/utils_test.go
@@ -192,7 +192,7 @@ func TestLoadRefData(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			filename, err := LoadRefData(context.Background(), tc.node, "./")
+			filename, err := LoadRefData(context.Background(), tc.node)
 			if tc.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/internal/updater/main.go
+++ b/internal/updater/main.go
@@ -77,7 +77,7 @@ func NewUpdater(ctx context.Context, filename string, useCloud bool) (*Updater, 
 	}
 
 	// Resolve $ref references for the components.
-	componentsFilename, err := config.LoadRefData(ctx, &raw.Components, path.Dir(filename))
+	componentsFilename, err := config.LoadRefData(ctx, &raw.Components)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION


<!--

Describe in detail the changes you are proposing, and the rationale.

-->

Currently, `components.$ref` reads the file from the location of `main.yaml`, but `mach_composer.variables_file` reads it from where the binary is executed (cwd). This PR makes `components.$ref` read the file from cwd as well, bringing its behavior in line with that of `mach_composer.variables_file`.

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

-->

Fixes #283

### BUG FIXES

<!--

Write a short description of your changes. Examples:

- Fixed a bug
- Added a new feature
- Updated documentation

--> 

- `components.$ref` now reads the file using cwd as the root, making it consistent with the `mach_composer.variables_file` import behavior.
