### PR TITLE
Update terraform versions in release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,10 +58,10 @@ jobs:
     needs: [goreleaser]
     name: Build and push docker image
     env:
-      DEFAULT_TERRAFORM: "1.3"
+      DEFAULT_TERRAFORM: "1.3.10"
     strategy:
       matrix:
-        terraform: ["0.14.11", "1.1.9", "1.2.9", "1.3.5"]
+        terraform: ["0.14.11", "1.1.9", "1.2.9", "1.3.10", "1.4.7", "1.5.7"]
         cloud: ["aws", "azure", "all"]
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently, we are using not the latest path versions for terraform

###  ENHANCEMENTS

Updated to latest patch releases of Terraform 1.3.x and added latest 2 minor versions
