### PR TITLE
Fixed iterating until beginning if commit not found in paths.

### DIFF
--- a/.changes/unreleased/Fixed-20230928-155812.yaml
+++ b/.changes/unreleased/Fixed-20230928-155812.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixed iterating until beginning if commit not found in paths.
+time: 2023-09-28T15:58:12.046751+02:00


### PR DESCRIPTION
Fixes #309

### BUG FIXES

Fixed iterating until the beginning if the first commit is not found in paths.
