### PR TITLE
Fix: Escape backslashes in component source string

### DIFF
--- a/.changes/unreleased/Fixed-20231031-152449.yaml
+++ b/.changes/unreleased/Fixed-20231031-152449.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Escape backslashes in Terraform module source path
+time: 2023-10-31T15:24:49.3225035+01:00

--- a/internal/generator/generate.go
+++ b/internal/generator/generate.go
@@ -268,5 +268,8 @@ func renderComponent(_ context.Context, cfg *config.MachConfig, site *config.Sit
 		tc.Source += fmt.Sprintf("?ref=%s", component.Definition.Version)
 	}
 
+    // Escape backslashes in paths (Windows path separator)
+	tc.Source = strings.Replace(tc.Source, "\\", "\\\\", -1);
+
 	return utils.RenderGoTemplate(tpl, tc)
 }


### PR DESCRIPTION
When defining components with a source to a (relative) local path in Windows, backslashes should be escaped within the module definition in `site.tf` for it to work. A single backslash is interpreted as escape character. Windows uses a backslash as path separator.