### PR TITLE
fix: Set correct backend for aws remote state

### DIFF
--- a/.changes/unreleased/Fixed-20240208-080605.yaml
+++ b/.changes/unreleased/Fixed-20240208-080605.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Set correct backend for aws remote state
+time: 2024-02-08T08:06:05.005615+01:00

--- a/internal/state/aws.go
+++ b/internal/state/aws.go
@@ -60,8 +60,8 @@ func (ar *AwsRenderer) RemoteState() (string, error) {
 
 	template := `
 	data "terraform_remote_state" "{{ .Key }}" {
-	  backend = "aws"
-	
+	  backend = "s3"
+
 	  config = {
 		  bucket         = "{{ .State.Bucket }}"
 		  key            = "{{ .State.KeyPrefix}}/{{ .Key }}"


### PR DESCRIPTION
For the AWS Remote state the backend is `s3`, not `aws`
