### PR TITLE
Fix: Escape backslashes in module source path for Windows

### DIFF
--- a/.changes/unreleased/Fixed-20240416-103813.yaml
+++ b/.changes/unreleased/Fixed-20240416-103813.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Escape backslashes in module source path for Windows
+time: 2024-04-16T10:38:13.8002367+02:00

--- a/internal/generator/component.go
+++ b/internal/generator/component.go
@@ -6,6 +6,7 @@ import (
 	"github.com/mach-composer/mach-composer-cli/internal/config"
 	"github.com/mach-composer/mach-composer-cli/internal/graph"
 	"github.com/mach-composer/mach-composer-cli/internal/utils"
+	"runtime"
 	"slices"
 	"strings"
 )
@@ -198,7 +199,13 @@ func renderComponentModule(_ context.Context, cfg *config.MachConfig, site *conf
 	if err != nil {
 		return "", err
 	}
-	tc.Source = vs
+
+    // Escape backslashes in paths (Windows path separator)
+    if runtime.GOOS == "windows" {
+        tc.Source = strings.Replace(vs, "\\", "\\\\", -1)
+    } else {
+        tc.Source = vs
+    }
 
 	val, err := utils.RenderGoTemplate(string(tpl), tc)
 	if err != nil {


### PR DESCRIPTION
**New PR with fix for resolving local windows paths**
Previous PR: https://github.com/mach-composer/mach-composer-cli/pull/323

I've tailored this fix specifically for Windows to simplify the acceptance process for you. It would be greatly appreciated if this could be merged soon, as I need to compile my own executable to utilize the latest release.