### PR TITLE
feat: add git fallback option to update command

### DIFF
--- a/.changes/unreleased/Added-20240917-115620.yaml
+++ b/.changes/unreleased/Added-20240917-115620.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Added git-fallback option to cloud update command. Usage; `mach-composer update --cloud --git-fallback`
+time: 2024-09-17T11:56:20.992197+02:00

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/rs/zerolog/log"
 	"os"
 	"strings"
+
+	"github.com/rs/zerolog/log"
 
 	"github.com/spf13/cobra"
 
@@ -22,6 +23,7 @@ var updateFlags struct {
 	commit        bool
 	commitMessage string
 	cloud         bool
+	gitFallback   bool
 }
 
 var updateCmd = &cobra.Command{
@@ -50,6 +52,7 @@ func init() {
 	updateCmd.Flags().BoolVarP(&updateFlags.commit, "commit", "c", false, "Automatically commits the change.")
 	updateCmd.Flags().StringVarP(&updateFlags.commitMessage, "commit-message", "m", "", "Use a custom message for the commit.")
 	updateCmd.Flags().BoolVar(&updateFlags.cloud, "cloud", false, "Use MACH composer cloud to check for updates.")
+	updateCmd.Flags().BoolVar(&updateFlags.gitFallback, "git-fallback", false, "Fallback to git if composer cloud check fails.")
 	updateCmd.Flags().StringArrayVarP(&updateFlags.components, "component", "", nil, "")
 
 	handleError(updateCmd.MarkFlagFilename("file", "yml", "yaml"))
@@ -72,7 +75,7 @@ func updateFunc(ctx context.Context, args []string) error {
 
 	writeChanges := !updateFlags.check
 
-	u, err := updater.NewUpdater(ctx, updateFlags.configFile, updateFlags.cloud)
+	u, err := updater.NewUpdater(ctx, updateFlags.configFile, updateFlags.cloud, updateFlags.gitFallback)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to update %s: %v\n", updateFlags.configFile, err.Error())
 		os.Exit(1)

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -3,10 +3,11 @@ package updater
 import (
 	"context"
 	"fmt"
-	"github.com/rs/zerolog/log"
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/rs/zerolog/log"
 
 	"github.com/mach-composer/mcc-sdk-go/mccsdk"
 	"gopkg.in/yaml.v3"
@@ -25,6 +26,7 @@ type PartialConfig struct {
 	isEncrypted bool
 	filename    string `yaml:"-"`
 	client      *mccsdk.APIClient
+	gitFallback bool
 }
 
 type PartialRawConfig struct {
@@ -65,7 +67,7 @@ type Updater struct {
 
 // NewUpdater creates an update to update the component versions in a config
 // file.
-func NewUpdater(ctx context.Context, filename string, useCloud bool) (*Updater, error) {
+func NewUpdater(ctx context.Context, filename string, useCloud bool, gitFallback bool) (*Updater, error) {
 	//TODO: Switch to using config.loadConfig to load the config file so we have a consistent way of loading the config
 	body, err := utils.AFS.ReadFile(filename)
 	if err != nil {
@@ -98,6 +100,7 @@ func NewUpdater(ctx context.Context, filename string, useCloud bool) (*Updater, 
 		ComponentsNode: &raw.Components,
 		Sops:           raw.Sops,
 		filename:       filepath.Base(filename),
+		gitFallback:    gitFallback,
 	}
 
 	// If we have a Sops node which is a mapping then we can assume that this

--- a/internal/updater/updates.go
+++ b/internal/updater/updates.go
@@ -3,11 +3,12 @@ package updater
 import (
 	"context"
 	"fmt"
-	"github.com/mach-composer/mach-composer-cli/internal/cloud"
-	"github.com/rs/zerolog/log"
 	"math"
 	"runtime"
 	"sync"
+
+	"github.com/mach-composer/mach-composer-cli/internal/cloud"
+	"github.com/rs/zerolog/log"
 
 	"github.com/mach-composer/mach-composer-cli/internal/config"
 
@@ -191,7 +192,7 @@ func getLastVersionCloud(ctx context.Context, cfg *PartialConfig, c *config.Comp
 		Execute()
 
 	if err != nil {
-		if c.Source.IsType(config.SourceTypeGit) {
+		if cfg.gitFallback && c.Source.IsType(config.SourceTypeGit) {
 			log.Ctx(ctx).Err(err).Msgf("Error checking for %s in MACH Composer Cloud, falling back to Git", c.Name)
 			return getLastVersionGit(ctx, c, origin)
 		}
@@ -200,7 +201,7 @@ func getLastVersionCloud(ctx context.Context, cfg *PartialConfig, c *config.Comp
 	}
 
 	if version == nil {
-		if c.Source.IsType(config.SourceTypeGit) {
+		if cfg.gitFallback && c.Source.IsType(config.SourceTypeGit) {
 			log.Ctx(ctx).Warn().Msgf("No version found for %s in MACH Composer Cloud, falling back to Git", c.Name)
 			return getLastVersionGit(ctx, c, origin)
 		}


### PR DESCRIPTION
Add `--git-fallback` option to the `update` command to make the fallback explicit and only when needed/desired.