### PR TITLE
fix: continue with error log when commits between versions cannot be found

### DIFF
--- a/.changes/unreleased/Fixed-20240930-131637.yaml
+++ b/.changes/unreleased/Fixed-20240930-131637.yaml
@@ -1,0 +1,4 @@
+kind: Fixed
+body: Continue with update proces even when commits / changelogs cannot be fetched
+  between old and new version
+time: 2024-09-30T13:16:37.40107+02:00

--- a/internal/updater/updates.go
+++ b/internal/updater/updates.go
@@ -224,26 +224,27 @@ func getLastVersionCloud(ctx context.Context, cfg *PartialConfig, c *config.Comp
 			Limit(200).
 			Execute()
 		if err != nil {
-			return nil, err
-		}
+			log.Ctx(ctx).Warn().Msgf("Could not fetch related commits between %s versions %s and %s: %s", c.Name, c.Version, version.Version, err)
+		} else {
 
-		for _, record := range paginator.Results {
-			change := CommitData{
-				Commit:  record.Commit,
-				Parents: record.Parents,
-				Message: record.Subject,
-				Author: CommitAuthor{
-					Email: record.Author.Email,
-					Name:  record.Author.Name,
-					Date:  record.Author.Date,
-				},
-				Committer: CommitAuthor{
-					Email: record.Committer.Email,
-					Name:  record.Committer.Name,
-					Date:  record.Committer.Date,
-				},
+			for _, record := range paginator.Results {
+				change := CommitData{
+					Commit:  record.Commit,
+					Parents: record.Parents,
+					Message: record.Subject,
+					Author: CommitAuthor{
+						Email: record.Author.Email,
+						Name:  record.Author.Name,
+						Date:  record.Author.Date,
+					},
+					Committer: CommitAuthor{
+						Email: record.Committer.Email,
+						Name:  record.Committer.Name,
+						Date:  record.Committer.Date,
+					},
+				}
+				cs.Changes = append(cs.Changes, change)
 			}
-			cs.Changes = append(cs.Changes, change)
 		}
 	}
 


### PR DESCRIPTION
In case of hotfix releases we switch to a different `branch` name but current versions defined in our component definitions are from the previous branch (`main` for example).
When performing `mach-composer update` it correctly retrieves a new version from Mach Cloud but fails fetching commits between old and new (because old does not exist on the new branch name).

This change will make sure this error is logged, but the process itself is not aborted and we can continue updating components.