### PR TITLE
fix: added sorting of state identifiers before compacting

### DIFF
--- a/.changes/unreleased/Fixed-20250110-144620.yaml
+++ b/.changes/unreleased/Fixed-20250110-144620.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Added sorting of remote state identifiers before compacting
+time: 2025-01-10T14:46:20.251554084+01:00

--- a/internal/generator/component_test.go
+++ b/internal/generator/component_test.go
@@ -1,0 +1,68 @@
+package generator
+
+import (
+	"github.com/mach-composer/mach-composer-cli/internal/config"
+	"github.com/mach-composer/mach-composer-cli/internal/config/variable"
+	"github.com/mach-composer/mach-composer-cli/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"testing"
+)
+
+type mockRenderer struct {
+	mock.Mock
+}
+
+func (m *mockRenderer) Identifier() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *mockRenderer) StateKey() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *mockRenderer) Backend() (string, error) {
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
+
+func (m *mockRenderer) RemoteState() (string, error) {
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
+
+func TestRenderRemoteSourcesCompactSources(t *testing.T) {
+
+	rr := new(mockRenderer)
+	rr.On("Identifier").Return("site/component").Times(2)
+	rr.On("StateKey").Return("component")
+	rr.On("RemoteState").Return("remote-state", nil)
+	rr.On("Backend").Return("backend", nil)
+
+	rr2 := new(mockRenderer)
+	rr2.On("Identifier").Return("site/component-2")
+	rr2.On("StateKey").Return("component-2")
+	rr2.On("RemoteState").Return("remote-state-2", nil)
+	rr.On("Backend").Return("backend-2", nil)
+
+	r := state.NewRepository()
+	r.Add(rr)
+	r.Add(rr2)
+	dup, _ := variable.NewScalarVariable("${component.component.value}")
+	dup2, _ := variable.NewScalarVariable("${component.component-2.value}")
+
+	sdup := variable.NewSliceVariable([]variable.Variable{dup2, dup})
+
+	scc := config.SiteComponentConfig{
+		Variables: map[string]variable.Variable{
+			"value":   dup,
+			"value_2": sdup,
+		},
+	}
+
+	resp, err := renderRemoteSources(r, "site", scc)
+	assert.NoError(t, err)
+	assert.Equal(t, "remote-state\nremote-state-2", resp)
+}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

-->

Fixes #472

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of your changes. Examples:

- Fixed a bug
- Added a new feature
- Updated documentation

--> 

-  because slices are not by default sorted, we have to sort them before compacting when generating the remote state components
