### PR TITLE
feat: use full-commit hash for mach-composer cloud

### DIFF
--- a/.changes/unreleased/Fixed-20250225-083100.yaml
+++ b/.changes/unreleased/Fixed-20250225-083100.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Instead of sending a short hash to mach composer cloud, use the fullh
+time: 2025-02-25T08:31:00.548152081+01:00

--- a/internal/gitutils/git.go
+++ b/internal/gitutils/git.go
@@ -258,11 +258,11 @@ func GetRecentCommits(ctx context.Context, basePath string, baseRevision, target
 		subject := strings.TrimSpace(fields[0])
 		parents := make([]string, len(c.ParentHashes))
 		for i, parent := range c.ParentHashes {
-			parents[i] = parent.String()[:7]
+			parents[i] = parent.String()
 		}
 
 		result[i] = GitCommit{
-			Commit:  c.Hash.String()[:7],
+			Commit:  c.Hash.String(),
 			Parents: parents,
 			Author: GitCommitAuthor{
 				Name:  c.Author.Name,


### PR DESCRIPTION
Instead of sending a short hash to mach composer cloud, use the full
hash
