### PR TITLE
Update sops provider version

### DIFF
--- a/internal/generator/templates/terraform.tmpl
+++ b/internal/generator/templates/terraform.tmpl
@@ -9,7 +9,7 @@ terraform {
     {{ if .IncludeSOPS }}
         sops = {
         source = "carlpett/sops"
-        version = "~> 0.5"
+        version = "~> 1.0"
         }
     {{ end }}
     }


### PR DESCRIPTION
There has been a 1.0.0 release for the provider so we don't get any update anymore.

