### PR TITLE
fix(ci): add cwd prefix to bake-file reference

### DIFF
--- a/.changes/unreleased/Dependency-20250512-230643.yaml
+++ b/.changes/unreleased/Dependency-20250512-230643.yaml
@@ -1,0 +1,3 @@
+kind: Dependency
+body: Added terraform 1.11.4 to build matrix
+time: 2025-05-12T23:06:43.659065+02:00

--- a/.changes/unreleased/Fixed-20250512-224649.yaml
+++ b/.changes/unreleased/Fixed-20250512-224649.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Added `cwd://` prefix for bake-file reference in release github action
+time: 2025-05-12T22:46:49.914831+02:00

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,7 @@ jobs:
       DEFAULT_TERRAFORM: "1.3.10"
     strategy:
       matrix:
-        terraform: [ "0.14.11", "1.1.9", "1.2.9", "1.3.10", "1.4.7", "1.5.7" ]
+        terraform: [ "0.14.11", "1.1.9", "1.2.9", "1.3.10", "1.4.7", "1.5.7", "1.11.4" ]
         cloud: [ "gcp", "aws", "azure", "all" ]
 
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -130,7 +130,7 @@ jobs:
         with:
           files: |
             ./docker-bake.hcl
-            ${{ steps.meta.outputs.bake-file }}
+            cwd://${{ steps.meta.outputs.bake-file }}
           targets: default-${{ matrix.cloud }}
           set: |
             base.args.TERRAFORM_VERSION=${{ matrix.terraform }}
@@ -171,7 +171,7 @@ jobs:
         with:
           files: |
             ./docker-bake.hcl
-            ${{ steps.meta.outputs.bake-file }}
+            cwd://${{ steps.meta.outputs.bake-file }}
           targets: cli
           push: true
 


### PR DESCRIPTION
The release GitHub action is broken now because of a breaking change in `docker/bake-action` GitHub action after upgrading from v5 to v6.

## Changes

- Added `cwd://` prefix to the bake-file reference in the GitHub action.
- Added terraform 1.11.4 to build matrix