### PR TITLE
chore: added shell installer

### DIFF
--- a/.changes/unreleased/Fixed-20250704-115212.yaml
+++ b/.changes/unreleased/Fixed-20250704-115212.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Added shell installer for ease of use
+time: 2025-07-04T11:52:12.397309325+02:00

--- a/README.md
+++ b/README.md
@@ -34,14 +34,30 @@ organisation.
 
 ## Installation
 
-### MacOS
+### Shell script
+
+Run the following command to install MACH composer on your system. The script will download the latest release of MACH composer and install it in your
+`$HOME/bin` directory. Make sure that this directory is in your `$PATH`.
+
+```
+$ curl -sfL https://raw.githubusercontent.com/mach-composer/mach-composer-cli/f08424b1bc38086696767a1ce05e1b0fbb199326/scripts/install-mach-composer.sh | bash
+```
+
+If you want to install a specific version, you can specify the `VERSION` environment variable:
+
+```
+$ export VERSION=v2.20.0
+$ curl -sfL https://raw.githubusercontent.com/mach-composer/mach-composer-cli/blob/main/scripts/install-mach-composer.sh | bash
+```
+
+### Brew
 
 ```bash
 brew tap mach-composer/mach-composer
 brew install mach-composer
 ```
 
-### Windows
+### Chocolatey (Windows)
 
 Windows installation through Chocolatery is currently unstable. We recommend to [download the latest release from GitHub
 Releases](https://github.com/mach-composer/mach-composer-cli/releases/latest). Also, it is recommended to run MACH composer through [WSL](https://learn.microsoft.com/en-us/windows/wsl/install).

--- a/scripts/install-mach-composer.sh
+++ b/scripts/install-mach-composer.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+if ! (set -o pipefail 2>/dev/null); then
+    echo "❌ This script requires bash. Please run it with: bash $0"
+    exit 1
+fi
+
+set -euo pipefail
+
+# Optional version from environment variable (default to latest from GitHub)
+VERSION="${VERSION:-$(curl -s https://api.github.com/repos/mach-composer/mach-composer-cli/releases/latest | jq -r .tag_name)}"
+VERSION_NO_V="${VERSION#v}"
+
+# Detect OS
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+case "$OS" in
+    linux|darwin|freebsd) ;;
+    msys*|mingw*|cygwin*) OS="windows" ;;
+    *)
+        echo "❌ Unsupported OS: $OS"
+        exit 1
+        ;;
+esac
+
+# Detect architecture
+ARCH="$(uname -m)"
+case "$ARCH" in
+    x86_64|amd64) ARCH="amd64" ;;
+    aarch64|arm64) ARCH="arm64" ;;
+    armv6l) ARCH="armv6" ;;
+    *)
+        echo "❌ Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
+# Determine file extension
+EXT="tar.gz"
+[[ "$OS" == "windows" ]] && EXT="zip"
+
+FILENAME="mach-composer-${VERSION_NO_V}-${OS}-${ARCH}.${EXT}"
+URL="https://github.com/mach-composer/mach-composer-cli/releases/download/${VERSION}/${FILENAME}"
+
+# Setup directories
+TARGET_DIR="$HOME/.local/bin"
+mkdir -p "$TARGET_DIR"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+echo "⬇️ Downloading $FILENAME..."
+curl -sL "$URL" -o "$TMP_DIR/$FILENAME"
+
+echo "📦 Extracting $FILENAME..."
+if [[ "$EXT" == "zip" ]]; then
+    unzip -q "$TMP_DIR/$FILENAME" -d "$TMP_DIR"
+else
+    tar -xzf "$TMP_DIR/$FILENAME" -C "$TMP_DIR"
+fi
+
+# Move binary from bin/ to target dir
+BIN_PATH="$TMP_DIR/bin/mach-composer"
+if [[ ! -f "$BIN_PATH" ]]; then
+    echo "❌ Binary not found at expected path: $BIN_PATH"
+    exit 1
+fi
+
+mv "$BIN_PATH" "$TARGET_DIR/mach-composer"
+chmod +x "$TARGET_DIR/mach-composer"
+
+echo "✅ mach-composer $VERSION installed to $TARGET_DIR"
+
+# Warn if not in PATH
+if ! echo "$PATH" | grep -q "$HOME/.local/bin"; then
+    echo "⚠️  $HOME/.local/bin is not in your PATH. You can add this to your shell config:"
+    echo 'export PATH="$HOME/.local/bin:$PATH"'
+fi


### PR DESCRIPTION
This pull request introduces a new shell installer for MACH Composer, improving the installation process and updating the documentation accordingly. The key changes include the addition of the shell script, updates to the `README.md` file to reflect the new installation method, and a changelog entry documenting the update.

### Shell Installer Addition:
* Added a new shell script, `scripts/install-mach-composer.sh`, to simplify the installation process. The script automatically detects the operating system and architecture, downloads the appropriate binary, and installs it to `$HOME/.local/bin`. It also provides support for specifying a version via the `VERSION` environment variable.

### Documentation Updates:
* Updated the `README.md` file to include a new "Shell script" section under installation methods. This section provides instructions for using the shell installer, including commands for installing the latest version or a specific version. Adjustments were also made to clarify other installation methods.

### Changelog Update:
* Added an entry to the changelog (`.changes/unreleased/Fixed-20250704-115212.yaml`) documenting the addition of the shell installer for ease of use.