### PR TITLE
feat: add --check-commits flag (default false) to be able to skip full commit checking on --auto mode

### DIFF
--- a/.changes/unreleased/Added-20260806-120000.yaml
+++ b/.changes/unreleased/Added-20260806-120000.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'Added `--check-commits` flag (default `true`) to `cloud register-component-version`. Set it to `false` to register the version hash without looking up and pushing the commits since the last version'
+time: 2026-08-06T12:00:00.000000000Z

--- a/docs/src/reference/cli/mach-composer_cloud_register-component-version.md
+++ b/docs/src/reference/cli/mach-composer_cloud_register-component-version.md
@@ -11,6 +11,7 @@ mach-composer cloud register-component-version [name] [version] [flags]
 ```
       --auto                          Add the version commits automatically based on the current branch
       --branch string                 The branch to use for the version. Defaults to the backend default if not set
+      --check-commits                 Look up the commits since the last version and register them with the new version. Only used in combination with --auto (default true)
       --create-component              Will create the component if it does not already exist
       --dry-run                       Dry run
       --git-filter-path stringArray   Filter commits based on given paths

--- a/docs/src/reference/cli/mach-composer_update.md
+++ b/docs/src/reference/cli/mach-composer_update.md
@@ -17,6 +17,7 @@ mach-composer update [flags]
   -f, --file string             YAML file to update. (default "main.yml")
       --git-fallback            Fallback to git if composer cloud check fails.
   -h, --help                    help for update
+      --short-hash              Use short (7 character) git hashes instead of full length hashes
 ```
 
 ### Options inherited from parent commands

--- a/internal/cloud/version.go
+++ b/internal/cloud/version.go
@@ -14,7 +14,7 @@ import (
 	"github.com/mach-composer/mach-composer-cli/internal/gitutils"
 )
 
-func RegisterComponentVersion(ctx context.Context, client ClientWrapper, repository gitutils.GitRepository, organization, project, componentKey, branch, version string, dryRun, auto, createComponent bool, gitFilterPaths []string) error {
+func RegisterComponentVersion(ctx context.Context, client ClientWrapper, repository gitutils.GitRepository, organization, project, componentKey, branch, version string, dryRun, auto, createComponent, checkCommits bool, gitFilterPaths []string) error {
 	lc, err := client.ListComponents(ctx, organization, project, 250)
 	if err != nil {
 		return err
@@ -45,7 +45,7 @@ func RegisterComponentVersion(ctx context.Context, client ClientWrapper, reposit
 	}
 
 	if auto {
-		return autoRegisterVersion(ctx, client, repository, organization, project, componentKey, dryRun, gitFilterPaths)
+		return autoRegisterVersion(ctx, client, repository, organization, project, componentKey, dryRun, checkCommits, gitFilterPaths)
 	} else {
 		if dryRun {
 			log.Info().Msgf("Would create new version: %s (branch=%s)", version, branch)
@@ -61,7 +61,7 @@ func RegisterComponentVersion(ctx context.Context, client ClientWrapper, reposit
 	}
 }
 
-func autoRegisterVersion(ctx context.Context, client ClientWrapper, repository gitutils.GitRepository, organization, project, componentKey string, dryRun bool, gitFilterPaths []string) error {
+func autoRegisterVersion(ctx context.Context, client ClientWrapper, repository gitutils.GitRepository, organization, project, componentKey string, dryRun, checkCommits bool, gitFilterPaths []string) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err
@@ -81,7 +81,7 @@ func autoRegisterVersion(ctx context.Context, client ClientWrapper, repository g
 	}
 
 	var lastVersion *mccsdk.ComponentVersion
-	if !dryRun {
+	if !dryRun && checkCommits {
 		lastVersion, err = client.GetLatestComponentVersion(ctx, organization, project, componentKey, branch)
 		if err != nil {
 			return err
@@ -108,6 +108,11 @@ func autoRegisterVersion(ctx context.Context, client ClientWrapper, repository g
 			return err
 		}
 		log.Info().Msgf("Created new version: %s (branch=%s)", createdVersion.Version, branch)
+	}
+
+	if !checkCommits {
+		log.Info().Msgf("Skipping commit lookup for version: %s", versionIdentifier)
+		return nil
 	}
 
 	commits, err := repository.GetRecentCommits(ctx, cwd, baseRef, branch, gitFilterPaths)

--- a/internal/cloud/version_test.go
+++ b/internal/cloud/version_test.go
@@ -24,7 +24,7 @@ func TestRegisterComponentVersionComponentNotFoundWithoutCreateComponent(t *test
 	version := "1.0.0"
 	var gitFilterPaths []string
 
-	err := RegisterComponentVersion(ctx, client, gitRepo, organization, project, componentKey, branch, version, false, false, false, gitFilterPaths)
+	err := RegisterComponentVersion(ctx, client, gitRepo, organization, project, componentKey, branch, version, false, false, false, true, gitFilterPaths)
 	assert.ErrorContains(t, err, "component test-component does not exist")
 	assert.True(t, client.AssertNotCalled(t, "CreateComponent"))
 	assert.True(t, client.AssertNotCalled(t, "CreateComponentVersion"))
@@ -44,7 +44,7 @@ func TestRegisterComponentVersionComponentNotFoundWithCreateComponentDryRun(t *t
 	version := "1.0.0"
 	var gitFilterPaths []string
 
-	err := RegisterComponentVersion(ctx, client, gitRepo, organization, project, componentKey, branch, version, true, false, true, gitFilterPaths)
+	err := RegisterComponentVersion(ctx, client, gitRepo, organization, project, componentKey, branch, version, true, false, true, true, gitFilterPaths)
 	assert.NoError(t, err)
 	assert.True(t, client.AssertNotCalled(t, "CreateComponent"))
 	assert.True(t, client.AssertNotCalled(t, "CreateComponentVersion"))
@@ -69,7 +69,7 @@ func TestRegisterComponentVersionComponentNotFoundWithCreateComponent(t *testing
 	version := "1.0.0"
 	var gitFilterPaths []string
 
-	err := RegisterComponentVersion(ctx, client, gitRepo, organization, project, componentKey, branch, version, false, false, true, gitFilterPaths)
+	err := RegisterComponentVersion(ctx, client, gitRepo, organization, project, componentKey, branch, version, false, false, true, true, gitFilterPaths)
 	assert.NoError(t, err)
 }
 
@@ -95,7 +95,7 @@ func TestRegisterComponentVersionComponentFound(t *testing.T) {
 	version := "1.0.0"
 	var gitFilterPaths []string
 
-	err := RegisterComponentVersion(ctx, client, gitRepo, organization, project, componentKey, branch, version, false, false, true, gitFilterPaths)
+	err := RegisterComponentVersion(ctx, client, gitRepo, organization, project, componentKey, branch, version, false, false, true, true, gitFilterPaths)
 	assert.NoError(t, err)
 	assert.True(t, client.AssertNotCalled(t, "CreateComponent"))
 }
@@ -127,7 +127,7 @@ func TestRegisterComponentVersionComponentFoundAutoGitRevisionNotFound(t *testin
 	version := "1.0.0"
 	var gitFilterPaths []string
 
-	err := RegisterComponentVersion(ctx, client, gitRepo, organization, project, componentKey, branch, version, false, true, true, gitFilterPaths)
+	err := RegisterComponentVersion(ctx, client, gitRepo, organization, project, componentKey, branch, version, false, true, true, true, gitFilterPaths)
 	assert.NoError(t, err)
 	assert.True(t, client.AssertNotCalled(t, "CreateComponent"))
 	assert.True(t, client.AssertNotCalled(t, "PushComponentVersionCommits"))
@@ -160,7 +160,7 @@ func TestRegisterComponentVersionComponentFoundAutoNoCommits(t *testing.T) {
 	version := "1.0.0"
 	var gitFilterPaths []string
 
-	err := RegisterComponentVersion(ctx, client, gitRepo, organization, project, componentKey, branch, version, false, true, true, gitFilterPaths)
+	err := RegisterComponentVersion(ctx, client, gitRepo, organization, project, componentKey, branch, version, false, true, true, true, gitFilterPaths)
 	assert.NoError(t, err)
 	assert.True(t, client.AssertNotCalled(t, "CreateComponent"))
 	assert.True(t, client.AssertNotCalled(t, "PushComponentVersionCommits"))
@@ -221,9 +221,41 @@ func TestRegisterComponentVersionComponentFoundAutoOK(t *testing.T) {
 	version := "1.0.0"
 	var gitFilterPaths []string
 
-	err := RegisterComponentVersion(ctx, client, gitRepo, organization, project, componentKey, branch, version, false, true, true, gitFilterPaths)
+	err := RegisterComponentVersion(ctx, client, gitRepo, organization, project, componentKey, branch, version, false, true, true, true, gitFilterPaths)
 	assert.NoError(t, err)
 	assert.True(t, client.AssertNotCalled(t, "CreateComponent"))
+}
+
+func TestRegisterComponentVersionComponentFoundAutoWithoutCheckCommits(t *testing.T) {
+	client := &ClientWrapperMock{}
+	client.On("ListComponents", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mccsdk.ComponentPaginator{
+		Results: []mccsdk.Component{
+			{
+				Key: "test-component",
+			},
+		},
+	}, nil)
+	client.On("CreateComponentVersion", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mccsdk.ComponentVersion{
+		Version: "test-component-version"}, nil)
+
+	gitRepo := &gitutils.GitRepositoryMock{}
+	gitRepo.On("GetCurrentBranch", mock.Anything, mock.Anything).Return("main", nil)
+	gitRepo.On("GetVersionInfo", mock.Anything, mock.Anything, mock.Anything).Return(&gitutils.GitVersionInfo{}, nil)
+
+	ctx := context.Background()
+	organization := "test-org"
+	project := "test-project"
+	componentKey := "test-component"
+	branch := "main"
+	version := "1.0.0"
+	var gitFilterPaths []string
+
+	err := RegisterComponentVersion(ctx, client, gitRepo, organization, project, componentKey, branch, version, false, true, true, false, gitFilterPaths)
+	assert.NoError(t, err)
+	assert.True(t, client.AssertCalled(t, "CreateComponentVersion", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything))
+	assert.True(t, client.AssertNotCalled(t, "GetLatestComponentVersion"))
+	assert.True(t, client.AssertNotCalled(t, "PushComponentVersionCommits"))
+	assert.True(t, gitRepo.AssertNotCalled(t, "GetRecentCommits"))
 }
 
 func TestRegisterComponentVersionComponentFoundAutoDryRun(t *testing.T) {
@@ -268,7 +300,7 @@ func TestRegisterComponentVersionComponentFoundAutoDryRun(t *testing.T) {
 	version := "1.0.0"
 	var gitFilterPaths []string
 
-	err := RegisterComponentVersion(ctx, client, gitRepo, organization, project, componentKey, branch, version, true, true, true, gitFilterPaths)
+	err := RegisterComponentVersion(ctx, client, gitRepo, organization, project, componentKey, branch, version, true, true, true, true, gitFilterPaths)
 	assert.NoError(t, err)
 	assert.True(t, client.AssertNotCalled(t, "CreateComponent"))
 	assert.True(t, client.AssertNotCalled(t, "CreateComponentVersion"))

--- a/internal/cmd/cloudcmd/component.go
+++ b/internal/cmd/cloudcmd/component.go
@@ -120,6 +120,11 @@ var componentRegisterVersionCmd = &cobra.Command{
 			return err
 		}
 
+		checkCommits, err := cmd.Flags().GetBool("check-commits")
+		if err != nil {
+			return err
+		}
+
 		client, err := cloud.NewClient(ctx)
 		if err != nil {
 			return err
@@ -135,7 +140,7 @@ var componentRegisterVersionCmd = &cobra.Command{
 			version = args[1]
 		}
 
-		return cloud.RegisterComponentVersion(ctx, cloud.NewClientWrapper(client), gitutils.NewGitRepositoryWrapper(), organization, project, componentKey, branch, version, dryRun, auto, createComponent, gitFilterPaths)
+		return cloud.RegisterComponentVersion(ctx, cloud.NewClientWrapper(client), gitutils.NewGitRepositoryWrapper(), organization, project, componentKey, branch, version, dryRun, auto, createComponent, checkCommits, gitFilterPaths)
 	},
 }
 
@@ -274,6 +279,7 @@ func init() {
 	componentRegisterVersionCmd.Flags().StringArray("git-filter-path", nil, "Filter commits based on given paths")
 	componentRegisterVersionCmd.Flags().String("branch", "", "The branch to use for the version. Defaults to the backend default if not set")
 	componentRegisterVersionCmd.Flags().Bool("create-component", false, "Will create the component if it does not already exist")
+	componentRegisterVersionCmd.Flags().Bool("check-commits", true, "Look up the commits since the last version and register them with the new version. Only used in combination with --auto")
 
 	CloudCmd.AddCommand(componentListVersionCmd)
 	registerContextFlags(componentListVersionCmd)


### PR DESCRIPTION
## Context

<img width="2698" height="161" alt="image" src="https://github.com/user-attachments/assets/8fd6dd08-f651-45ef-ac3b-33c9f8659bab" />

It happens quite some times that nil is found for commits, resulting in timeouts on the lookup for very large codebases.

## Changes

- Add --check-commits parameter (default true) to skip commit checks on --auto mode
- Add unit test
- Update docs (which also added the 'missing' --short-hash (from an earlier forgotten docs generation)
